### PR TITLE
fix read properties use callback mode, then update & save issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -291,7 +291,6 @@ function Editor(text, path) {
 			switch(node.type) {
 				case "literal":
 					buffer.push(node.text);
-					if(node.parent) { buffer.push(text.substring(node.end, node.parent.end)); }
 					break;
 				case "key":
 				case "value":

--- a/test/test.js
+++ b/test/test.js
@@ -84,6 +84,21 @@ editor3.set("key", "val");
 editor3.set("key", undefined);
 assert.equal(editor3.toString().trim(), "stay=ok");
 
+prop.createEditor("./test-cases.properties", function(err, editor) {
+	var properties = {};
+	properties.lala = 'whatever';
+	properties.website = 'whatever';
+	properties.language = 'whatever';
+	properties.message = 'whatever';
+	properties['key\ with\ spaces'] = 'whatever';
+	properties.tab = 'whatever';
+	properties['long-unicode'] = 'whatever';
+	properties['another-test'] = 'whatever';
+	for (var item in properties) {
+		editor.set(item, properties[item]);
+	}
+	editor.save('./test-cases-copy.properties');
+});
 
 // java ReadProperties test-cases.properties
 // javac ReadProperties.java


### PR DESCRIPTION
when use the callback mode to create the `editor`, then update the value and save, the file messed up.

it seems commit d6bee640e6a3e34782d6d37bc4008298cd35964a introduce the bug.
